### PR TITLE
using new RevGadgets::readTrace inside convenience::readTrace

### DIFF
--- a/R/readTrace.R
+++ b/R/readTrace.R
@@ -32,93 +32,24 @@
 #'
 #' \dontrun{
 #' file <- system.file("extdata",
-#'     "sub_models/primates_cytb_covariotide.p", package="RevGadgets")
-#' one_trace <- readTrace(paths = file)
+#'     "sub_models/primates_cytb_GTR_mini.p", package="RevGadgets")
+#' one_trace <- readTrace(paths = file, delim = "\t", skip = 0)
 #' multi_trace <- readTrace(paths = c(file, file))
 #' }
 #' @export
 
 readTrace <- function(paths, format = "simple",
-                      delim, burnin = 0, check.names = FALSE, skip, ...){
-  
-  # enforce argument matching
-  
-  character_paths_are_strings <- is.character(paths)
-  if ( any(character_paths_are_strings == FALSE) == TRUE ) {
-    # print out the ones that are not character strings
-    cat( "Some paths are not character strings:",
-         paste0("\t",paths[character_paths_are_strings == FALSE]), sep="\n")
-    stop()
-  }
-  
-  do_files_exist <- file.exists(paths)
-  if ( any(do_files_exist == FALSE) == TRUE ) {
-    # print out paths to files that don't exist
-    cat( "Some files do not exist:",
-         paste0("\t",paths[do_files_exist == FALSE]), sep="\n")
-    stop()
-  }
-  
-  format <- match.arg(format, choices = c("simple", "complex"))
-  
-  if (is.character(delim) == FALSE) stop("delim must be a single character string")
-  
-  if (is.numeric(burnin) == FALSE) stop("burnin must be a single numeric value")
-  if (burnin < 0) stop("burnin must be a positive value")
-  
-  num_paths <- length(paths)
-  
-  # check that the file headings match for all traces
-  
-  header <- vector("list", num_paths)
-  for (i in 1:num_paths) {
-    header[[i]] <- colnames(utils::read.table(file = paths[i], header = TRUE, skip = skip, sep = delim, check.names = check.names, nrows=0))
-  }
-  
-  all_headers <- unique(unlist(header))
-  for (i in 1:length(header)) {
-    if (setequal(all_headers, header[[i]]) == FALSE) {
-      stop("Not all headers of trace files match")
-    }
-  }
-  
-  
-  # read in the traces
-  
-  if (format == "simple") {
-    output <- vector("list", num_paths)
-    for (i in 1:num_paths) {
-      
-      cat(paste0("Reading in log file ",i),"\n",sep="")
-      
-      out <- utils::read.table(file = paths[i], header = TRUE,
-                               sep = delim, check.names = check.names, skip = skip, ...)
-      
-      if (burnin >= nrow(out)) stop("Burnin larger than provided trace file")
-      
-      if (burnin >= 1) {
-        output[[i]] <- out[(burnin+1):nrow(out), ]
-      } else if (burnin < 1 & burnin > 0) {
-        discard <- ceiling(burnin*nrow(out))
-        output[[i]] <- out[(discard+1):nrow(out), ]
-      } else if (burnin == 0) {
-        output[[i]] <- out
-      } else {
-        stop("What have you done?")
-      }
-    }
-  } else if (format == "complex") {
-    stop("Complex trace type currently not supported")
-  } else {
-    stop("Format is not of type simple or complex")
-  }
-  
+                      delim, burnin = 0, check.names = FALSE, ...){
+
+  # read output using RevGadgets  
+  output <- RevGadgets::readTrace(paths, format, delim, burnin, check.names, ...)
+
+  # convert to rwty.chain object  
   treelist <- NULL
   gens.per.tree <- NULL
   ptable <- output[[1]]
   output <- list("trees" = treelist, "ptable" = ptable, "gens.per.tree" = gens.per.tree)
   class(output) <- "rwty.chain"
-  
   
   return(output)
 }


### PR DESCRIPTION
We decided not to offload all of convenience::readTrace functionality to RevGadgets::readTrace because your changes to readTrace significantly change the structure of the output object, so we would have to change all downstream functions to accommodate the new format.

However, we've updated RevGadgets::readTrace so that it allows you to provide skip (actually, skip just gets passed as ... to all calls of read.table). On this fork, we modified convenience::readTrace to use this new version of RevGadgets::readTrace internally, then modify the result to an rwty.chain object as you previously did.

Unfortunately, this does not resolve the issue of conflicting readTrace functions. We think the best solution here is to rename convenience::readTrace, but we're not sure how/when you intend it to be used so we did not make that change. We'll leave that up to you.